### PR TITLE
Fix assignment tag, for 2.0 compatibility

### DIFF
--- a/sheets/templatetags/sheets.py
+++ b/sheets/templatetags/sheets.py
@@ -81,6 +81,6 @@ class Sheet(object):
         return [[force_text(cell) for cell in row] for row in reader]
 
 
-@register.assignment_tag(name='csv')
+@register.simple_tag(name='csv')
 def csv_tag(key, gid=None):
     return Sheet(key, gid)


### PR DESCRIPTION
Seems as if assignment_tag is not compatible with Django 2.0, solution would be to use simple_tag instead, to allow users to use the 'csv' tag.